### PR TITLE
Set tokenizer model max length to 512

### DIFF
--- a/pandas_utilities/hf_sentiment.py
+++ b/pandas_utilities/hf_sentiment.py
@@ -37,6 +37,7 @@ def process_comments(df, model_name):
     """
     # Load model and tokenizer once for efficiency
     model, tokenizer = load_model_and_tokenizer(model_name)
+    tokenizer.model_max_length = 512
 
     # Function to analyze a single comment
     def analyze_and_label(comment):


### PR DESCRIPTION
Set the tokenizer's maximum model length to 512 for sentiment analysis.